### PR TITLE
Fix lua_ls settings configuration

### DIFF
--- a/lua/configs/lspconfig.lua
+++ b/lua/configs/lspconfig.lua
@@ -4,7 +4,7 @@ require("nvchad.configs.lspconfig").defaults()
 local lspconfig = require "lspconfig"
 
 -- EXAMPLE
-local servers = { "html", "cssls", "ts_ls", "eslint", "lua_ls"}
+local servers = { "html", "cssls", "ts_ls", "eslint" }
 local nvlsp = require "nvchad.configs.lspconfig"
 
 -- lsps with default config
@@ -16,8 +16,11 @@ for _, lsp in ipairs(servers) do
   }
 end
 
-lspconfig.lua_ls.setup({
-  setetings = {
+lspconfig.lua_ls.setup {
+  on_attach = nvlsp.on_attach,
+  on_init = nvlsp.on_init,
+  capabilities = nvlsp.capabilities,
+  settings = {
     Lua = {
       diagnostics = {
         globals = { "vim" },
@@ -27,10 +30,10 @@ lspconfig.lua_ls.setup({
       },
       telemetry = {
         enable = false,
-      }
-    }
-  }
-})
+      },
+    },
+  },
+}
 
 -- configuring single server, example: typescript
 -- lspconfig.ts_ls.setup {


### PR DESCRIPTION
## Summary
- correct the lua_ls setup to use the proper settings key with Lua diagnostics, runtime, and telemetry options
- rely on the dedicated lua_ls setup while keeping nvchad defaults to avoid duplicate configurations

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69489eb2d8348321be58b7ae518a7b84)