### PR TITLE
Fix treesitter setup invocation

### DIFF
--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -3,7 +3,7 @@ return {
   lazy = false,
   run = ':TSUpdate',
   config = function()
-    require'nvim-treesitter.configs'setup {
+    require("nvim-treesitter.configs").setup({
       ensure_installed = { 'javascript', 'typescript', 'tsx'},
       highlight = {
         enable = true,
@@ -12,6 +12,6 @@ return {
         enable = true,
         disable = {},
       },
-    }
+    })
   end
 }


### PR DESCRIPTION
### Motivation
- The `nvim-treesitter` configuration used a malformed call that could cause a runtime error during plugin setup.
- The change aims to ensure the Treesitter plugin is initialized with the proper `setup` invocation so it loads reliably.
- Table syntax around the setup call must remain valid after updating the call style.

### Description
- Updated `lua/plugins/treesitter.lua` to replace the malformed `require'nvim-treesitter.configs'setup { ... }` with `require("nvim-treesitter.configs").setup({ ... })`.
- Adjusted parentheses/braces so the Lua table remains syntactically correct and preserved the existing configuration keys like `ensure_installed`, `highlight`, and `fold`.
- No behavioral changes were made to the configuration values; only the invocation style was corrected.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694af05431548321a85fe83a3049ce43)